### PR TITLE
Correct is_ext() usage in POD

### DIFF
--- a/lib/Media/Type/Simple.pm
+++ b/lib/Media/Type/Simple.pm
@@ -377,9 +377,9 @@ sub ext3_from_type {
 
 =item is_ext
 
-  if (is_ext("image/jpeg")) { ... }
+  if (is_ext("jpeg")) { ... }
 
-  if ($o->is_type("image/jpeg")) { ... }
+  if ($o->is_ext("jpeg")) { ... }
 
 Returns a true value if the extension is defined in the system.
 


### PR DESCRIPTION
is_ext() takes a file extention, not a media type.