### PR TITLE
Bugfix: edge cases for is_type()

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,8 +37,9 @@ recommends(
 );
 
 test_requires(
-    'Test::Fork'      => 0,
-    'Test::More'      => 0,
+    'Test::Fork'       => 0,
+    'Test::More'       => 0,
+    'Test::NoWarnings' => 0,
 );
 
 install_share 'share';

--- a/lib/Media/Type/Simple.pm
+++ b/lib/Media/Type/Simple.pm
@@ -223,6 +223,7 @@ releases.
 sub is_type {
     my ($type) = args;
     my ($cat, $spec)  = split_type($type);
+    return if ! length $spec;
     return self->{types}->{$cat}->{$spec};
 }
 

--- a/lib/Media/Type/Simple.pm
+++ b/lib/Media/Type/Simple.pm
@@ -223,7 +223,7 @@ releases.
 sub is_type {
     my ($type) = args;
     my ($cat, $spec)  = split_type($type);
-    return if ! length $spec;
+    return if ! defined $spec || ! length $spec;
     return self->{types}->{$cat}->{$spec};
 }
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -4,8 +4,9 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::NoWarnings;
 
-plan tests => 32;
+plan tests => 37;
 
 use_ok("Media::Type::Simple");
 
@@ -15,6 +16,9 @@ can_ok("Media::Type::Simple",
 ok(is_type("image/jpeg"), "is_type");
 
 ok(!is_type("image/wxyz-foobar"), "is_type");
+ok(!is_type("image/"), "is_type - false if no subtype provided");
+ok(!is_type("image"), "is_type - false when only type provided");
+ok(!is_type(""), "is_type - empty string returns false");
 
 my @as = alt_types("image/jpeg");
 is_deeply(\@as, [qw( image/jpeg image/pipeg image/pjpeg )], "alt_types");
@@ -41,6 +45,7 @@ $e = ext3_from_type("image/jpeg");
 is($e, "jpg", "scalar ext3_from_type");
 
 ok(is_ext("jpeg"), "is_ext");
+ok(!is_ext(""), "is_ext - empty string returns false");
 
 my @ts = type_from_ext("jpeg");
 is_deeply(\@ts, [qw( image/jpeg image/pipeg image/pjpeg )], "array type_from_ext");
@@ -102,9 +107,4 @@ is($t, "image/jpeg", "scalar type_from_ext");
 	is_deeply(\@es, [qw( jpeg jpg jpe jfif jpeg_file )], "add_exten");
 
 }
-
-
-
-
-
 


### PR DESCRIPTION
Resolves issues reported in [RT:66513](https://rt.cpan.org/Public/Bug/Display.html?id=66513) for `is_type()`:
  * no warnings generated when media type is NOT of the form `type/subtype`
  * verify that `is_type` returns false for an empty string.